### PR TITLE
Bug fix for core number different from 8

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,9 @@ fn main() -> Result<(), Error> {
     let mut world = Context::new();
     let cpus = num_cpus::get();
     let mut deepness: f64 = 0.0;
+    if (world.height % cpus as u32) != 0{
+        println!("WARNING: HardCoded resolution height({}) should be divisable by the number of threads:{}",world.height,cpus)
+    }
 
     let window = {
         let size =
@@ -185,7 +188,7 @@ impl Context {
         let down_right_ = Point { x: 0.8, y: -1.5 };
 
         let width_ = 1000;
-        let height_ = 1000;
+        let height_ = 960;
 
         Self {
             up_left: up_left_,
@@ -213,7 +216,7 @@ impl Context {
 
             let number = mandelbrot::ComplexNumber { real: x, img: y };
             let degree: u8 =
-                mandelbrot::mandebrot_set_degree(number, self.iterations, self.threshold) as u8;
+                mandelbrot::mandelbrot_set_degree(number, self.iterations, self.threshold) as u8;
             let channel = 0xff - degree;
             let color = [channel, channel, channel, 0xff];
 
@@ -230,7 +233,7 @@ impl Context {
 
             let number = mandelbrot::ComplexNumber { real: x, img: y };
             let degree: u8 =
-                mandelbrot::mandebrot_set_degree(number, self.iterations, self.threshold) as u8;
+                mandelbrot::mandelbrot_set_degree(number, self.iterations, self.threshold) as u8;
             let channel = 0xff - degree;
             let color = [channel, channel, channel, 0xff];
 
@@ -250,7 +253,7 @@ impl Context {
 
                 let number = mandelbrot::ComplexNumber { real: x, img: y };
                 let degree: u8 =
-                    mandelbrot::mandebrot_set_degree(number, self.iterations, self.threshold) as u8;
+                    mandelbrot::mandelbrot_set_degree(number, self.iterations, self.threshold) as u8;
                 stored_degree = degree;
                 let channel = 0xff - degree;
                 let color = [channel, channel, channel, 0xff];

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,7 @@ fn main() -> Result<(), Error> {
     let mut world = Context::new();
     let cpus = num_cpus::get();
     let mut deepness: f64 = 0.0;
-    if (world.height % cpus as u32) != 0{
+    if (world.height % cpus as u32) != 0 {
         println!("WARNING: HardCoded resolution height({}) should be divisable by the number of threads:{}",world.height,cpus)
     }
 
@@ -253,7 +253,8 @@ impl Context {
 
                 let number = mandelbrot::ComplexNumber { real: x, img: y };
                 let degree: u8 =
-                    mandelbrot::mandelbrot_set_degree(number, self.iterations, self.threshold) as u8;
+                    mandelbrot::mandelbrot_set_degree(number, self.iterations, self.threshold)
+                        as u8;
                 stored_degree = degree;
                 let channel = 0xff - degree;
                 let color = [channel, channel, channel, 0xff];

--- a/src/mandelbrot.rs
+++ b/src/mandelbrot.rs
@@ -52,7 +52,10 @@ impl ComplexNumber {
 
 pub fn mandelbrot_set_degree(candidate: ComplexNumber, max_steps: i64, threshold: i64) -> i64 {
     let c = candidate;
-    let mut z = ComplexNumber { real: 0.0, img: 0.0 };
+    let mut z = ComplexNumber {
+        real: 0.0,
+        img: 0.0,
+    };
     let mut index: i64 = 0;
 
     while index < max_steps && (z.magnetude() < threshold as f64) {

--- a/src/mandelbrot.rs
+++ b/src/mandelbrot.rs
@@ -50,7 +50,7 @@ impl ComplexNumber {
     }
 }
 
-pub fn mandebrot_set_degree(candidate: ComplexNumber, max_steps: i64, threshold: i64) -> i64 {
+pub fn mandelbrot_set_degree(candidate: ComplexNumber, max_steps: i64, threshold: i64) -> i64 {
     let c = candidate;
     let mut z = ComplexNumber { real: 0.0, img: 0.0 };
     let mut index: i64 = 0;


### PR DESCRIPTION
Now works by default with: 1, 2, 4, 8, 12, 16, 32 cores.

Issue is that in function parallel_draw() and parallel_draw_low_res() the 'slice_size = (total_pixel / thread_num)'may not result in a exact division. This causes misalignments on the frames, Issue is mainly caused by height since the `slices` are horizontal lines.